### PR TITLE
Corrections and sourcetype definition

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -14,10 +14,14 @@ TIME_FORMAT = %m/%d/%Y %H:%M:%S %Z
 SHOULD_LINEMERGE = true
 BREAK_ONLY_BEFORE_DATE = true
 
+# Example {"data": {"additionalDetails": {"path": "a/b/c"}, "availabilityDomain": "all", "compartmentId": "a.b.c.d.e", "compartmentName": "namecompartment", "definedTags": {}, "eventGroupingId": "000abcdef", "eventName": "readdockerrepositorymetadata", "freeformTags": {}, "identity": {"authType": "USER", "callerId": "f.g.h.i.j", "callerName": "caller-container-deploy", "consoleSessionId": "", "credentials": "", "ipAddress": "xxx.yyy.zzz.ttt", "principalId": "h.i.j.k", "principalName": "principal-container-deploy", "tenantId": "k.lm.n.o", "userAgent": "ua/1"}, "message": "/v2/path/path/path/path/sha256:SHAID MSG", "request": {"action": "HEAD", "headers": {}, "id": "01234abcdef", "parameters": {}, "path": "/v2/path/path/path/blobs/sha256:SHAID"}, "resourceId": "", "response": {"headers": {}, "message": null, "payload": {}, "responseTime": null, "status": "404"}, "stateChange": {"current": {}, "previous": {}}}, "dataschema": "2.0", "id": "ID", "oracle": {"compartmentid": "a.b.c.d", "ingestedtime": "2023-04-21T07:22:09.450Z", "loggroupid": "_Audit", "tenantid": "a.b.c.d.e"}, "source": "", "specversion": "1.0", "time": "2023-04-21T07:22:01.632Z", "type": "com.oraclecloud.artifacts.readdockerrepositorymetadata"}
+# Example time field: "time": "2023-04-21T07:22:01.632Z",
 [oci_logging]
 TRUNCATE=0
 TIME_PREFIX=\"time\"\:
+TIME_FORMAT = %m/%d/%YT%H:%M:%S.%3Q%Z
 MAX_TIMESTAMP_LOOKAHEAD=40
 # LINE_BREAKER = ([\n\r]+)   
 SHOULD_LINEMERGE=false
 TRANSFORMS-oci_sourcetype = oci_sourcetype_reassign
+TRANSFORMS-oci_host = oci_host_reassign

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -1,5 +1,12 @@
+# Example{"data": {"additionalDetails": {"path": "a/b/c"}, "availabilityDomain": "all", "compartmentId": "a.b.c.d.e", "compartmentName": "namecompartment", "definedTags": {}, "eventGroupingId": "000abcdef", "eventName": "readdockerrepositorymetadata", "freeformTags": {}, "identity": {"authType": "USER", "callerId": "f.g.h.i.j", "callerName": "caller-container-deploy", "consoleSessionId": "", "credentials": "", "ipAddress": "xxx.yyy.zzz.ttt", "principalId": "h.i.j.k", "principalName": "principal-container-deploy", "tenantId": "k.lm.n.o", "userAgent": "ua/1"}, "message": "/v2/path/path/path/path/sha256:SHAID MSG", "request": {"action": "HEAD", "headers": {}, "id": "01234abcdef", "parameters": {}, "path": "/v2/path/path/path/blobs/sha256:SHAID"}, "resourceId": "", "response": {"headers": {}, "message": null, "payload": {}, "responseTime": null, "status": "404"}, "stateChange": {"current": {}, "previous": {}}}, "dataschema": "2.0", "id": "ID", "oracle": {"compartmentid": "a.b.c.d", "ingestedtime": "2023-04-21T07:22:09.450Z", "loggroupid": "_Audit", "tenantid": "a.b.c.d.e"}, "source": "", "specversion": "1.0", "time": "2023-04-21T07:22:01.632Z", "type": "com.oraclecloud.artifacts.readdockerrepositorymetadata"}
+
 [oci_sourcetype_reassign]
-REGEX = \"type\"\:\"([^\"]+)
-FORMAT = sourcetype::$1
+REGEX = \"type\"\:\s*?\"([^\"]+)
+FORMAT = sourcetype::oci:$1
 DEST_KEY = MetaData:Sourcetype
 
+
+[oci_host_reassign]
+REGEX = \"instanceid\"\s*\:\s*\"([^\"]+?)\"
+FORMAT = host::$1
+DEST_KEY = MetaData:Host


### PR DESCRIPTION
This Pull request is risky since it changes the definition of the sourcetype (it adds a prefix). 
The change does:
1) Corrects the REGEX of assignment of sourcetype to take into account that should have a space between type and its values
2) Corrects the sourcetype to have a oci: prefix in order to be able to classify properly the different sourcetypes. 
The reason is because oci delivers many types and not having a common prefix is not really according to the recomendation of splunk of keeping the vendor and product in front of the sourcetype. In this case we dont add the vendor but could have been a solution
3) Creates an assignment of host dinamically by the instanceid of the event
4) Defines a proper TIME_FORMAT instead of relying in the default
5) Adds the call the transforms that reassigns also the host