### PR TITLE
Release 3.0.0

### DIFF
--- a/README/release-notes.md
+++ b/README/release-notes.md
@@ -1,4 +1,9 @@
-# OCI Logging Add-On v2
+# OCI Logging Add-On 
+## Release 3.0.0
+- Validating OCI Streaming endpoint URL for HTTPS 
+- Added support for pasting in OCI API Key.  This can be an RSA key or an OCI Console Key for a LOCAL OCI IAM user.
+- Depreciated OCI API key upload feature
+
 ## Release 2.3.2
 - Added retry logic for 50x responses from OCI Streaming
 - Moved README.txt for Splunkbase AppInspect 

--- a/bin/oci_logging.py
+++ b/bin/oci_logging.py
@@ -417,8 +417,8 @@ class Stream(Script):
 
                 logger.debug("function: stream_event: Stream Client Created for file system API Key")
             
-            ## Using Uploaded OCI API Key
-            elif "-----BEGIN RSA PRIVATE KEY-----" in self.input_item["private_key"]:
+            ## Using OCI API Key as simplepassword
+            elif "-----BEGIN " in self.input_item["private_key"]:
                 logger.debug("function: stream_event: Using UI uploaded API Key")
                 global_user_ocid = self.input_item["user_ocid"]
                 global_tenancy_ocid = self.input_item["tenancy_ocid"]

--- a/bin/oci_logging.py
+++ b/bin/oci_logging.py
@@ -308,7 +308,10 @@ class Stream(Script):
         return scheme
 
     def validate_input(self, definition):
-        return
+        stream_endpoint = definition.parameters["stream_endpoint"] 
+        try:
+            if not stream_endpoint.startswith("https://") : raise ValueError("%s is not valid HTTPS Streaming Endpoint" % stream_endpoint)   
+        except ValueError: raise ValueError("%s is not valid HTTPS Streaming Endpoint" % stream_endpoint)   
 
     def disable_input(self, input_name):
         global active

--- a/bin/oci_logging.py
+++ b/bin/oci_logging.py
@@ -424,15 +424,16 @@ class Stream(Script):
                 global_tenancy_ocid = self.input_item["tenancy_ocid"]
                 global_fingerprint = self.input_item["fingerprint"]
                 global_private_key = self.input_item["private_key"]
-                splitted = global_private_key.split('-----BEGIN RSA PRIVATE KEY-----')
-                if len(splitted) != 2:
-                    logger.error("Invalid API Key, must be an RSA Key. Spiltted: " + str(len(splitted)))
-                    exit()
-                replaced = splitted[1]
-                private_key = ("-----BEGIN RSA PRIVATE KEY-----" + replaced[:-2]).replace('\\n', '\n')
-                WINDOWS_LINE_ENDING = '\r\n'
-                UNIX_LINE_ENDING = '\n'
-                private_key = private_key.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING)
+
+                if "-----BEGIN RSA PRIVATE KEY-----" in global_private_key:
+                    raw_key = global_private_key.split("-----BEGIN RSA PRIVATE KEY-----")[1].split("-----END RSA PRIVATE KEY-----")[0]
+                    raw_key = raw_key.replace(" ", "\n")
+                    private_key = "-----BEGIN RSA PRIVATE KEY-----\n" + raw_key + "-----END RSA PRIVATE KEY-----"
+
+                if "-----BEGIN PRIVATE KEY-----" in global_private_key:
+                    raw_key = global_private_key.split("-----BEGIN PRIVATE KEY----- ")[1].split("-----END PRIVATE KEY-----")[0]
+                    raw_key = raw_key.replace(" ", "\n")
+                    private_key = "-----BEGIN PRIVATE KEY-----\n" + raw_key + "-----END PRIVATE KEY-----"
 
                 if global_private_key_password is None:
                     logger.debug("function: stream_event: API Key is not using a password")

--- a/default/app.conf
+++ b/default/app.conf
@@ -8,7 +8,7 @@ label = OCI Logging Addon
 [launcher]
 author = Splunk Works
 description = This app streams OCI Logs and OCI Events from OCI Streaming
-version = 2.3.3
+version = 3.0.0
 
 [package]
 id = TA-oci-logging-addon

--- a/default/data/ui/manager/oci_logging.xml
+++ b/default/data/ui/manager/oci_logging.xml
@@ -46,7 +46,12 @@
           <view name="create"/>
           <view name="list"/>
         </element>
-            <element name="private_key_location" label="OCI API Key File Location">
+        <element name="private_key" type="simplepassword" label="Private Key">
+          <view name="create"/>
+          <view name="edit"/>
+          <key name="exampleText">You paste in your OCI API Key content here. The key should be Private RSA Key in PEM format or OCI Console key from LOCAL USER. Directions for RSA key creation are <![CDATA[<a target="_blank" href="https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two">]]>here<![CDATA[</a>]]></key>
+        </element>        
+        <element name="private_key_location" label="OCI API Key File Location">
               <key name="exampleText">Fully qualified file name of the OCI API Key on the Heavy Forwarder's file system. Example: /opt/splunk/etc/apps/TA-oci-logging-addon/keys/key.pem</key>
               <view name="list"/>
               <view name="edit"/>
@@ -175,10 +180,6 @@
           <view name="edit"/>
           <view name="create"/>
           <elements>
-          <element name="private_key" type="fileupload" label="Private Key">
-          <view name="create"/>
-          <key name="exampleText">DEPRECIATED - You can upload a Private RSA Key in PEM format. Directions for RSA key creation are <![CDATA[<a target="_blank" href="https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two">]]>here<![CDATA[</a>]]></key>
-        </element>
             <element name="partition" label="Worker Processes">
               <key name="exampleText">Number of partitions in the <![CDATA[<a target="_blank" href="https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/partitioningastream.htm#partitioning_a_stream">]]>OCI Stream Pool<![CDATA[</a>]]></key>
               <view name="list"/>


### PR DESCRIPTION
## Release 3.0.0
- Validating OCI Streaming endpoint URL for HTTPS 
- Added support for pasting in OCI API Key.  This can be an RSA key or an OCI Console Key for a LOCAL OCI IAM user.
- Depreciated OCI API key upload feature